### PR TITLE
feat: 관리자 페이지에서 회원 목록 조회 및 삭제

### DIFF
--- a/src/main/java/numble/team4/shortformserver/common/config/SecurityConfig.java
+++ b/src/main/java/numble/team4/shortformserver/common/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST, "/v1/users/following/{followId}", "/v1/users/email", "/v1/videos/{videoId}/likes").hasAnyRole(MEMBER.name(), ADMIN.name())
                 .antMatchers(HttpMethod.PUT, "/v1/users/image", "/v1/users/name").hasAnyRole(MEMBER.name(), ADMIN.name())
                 .antMatchers(HttpMethod.DELETE, "/v1/videos/likes/{likesId}", "/v1/users/following/{toMemberId}").hasAnyRole(MEMBER.name(), ADMIN.name())
+                .antMatchers(HttpMethod.GET, "/v1/users").hasRole(ADMIN.name())
+                .antMatchers(HttpMethod.DELETE, "/v1/users/**").hasRole(ADMIN.name())
                 .antMatchers("/login/oauth2/code/**", "/renew", "/v1/users/email/auth").permitAll()
                 .anyRequest().authenticated()
       

--- a/src/main/java/numble/team4/shortformserver/member/member/application/MailService.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/application/MailService.java
@@ -50,7 +50,7 @@ public class MailService {
         StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < 6; i++) {
-            sb.append(Integer.toString(rand.nextInt(10)));
+            sb.append(rand.nextInt(10));
         }
         return sb.toString();
     }

--- a/src/main/java/numble/team4/shortformserver/member/member/application/MemberService.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/application/MemberService.java
@@ -3,19 +3,28 @@ package numble.team4.shortformserver.member.member.application;
 import lombok.RequiredArgsConstructor;
 import numble.team4.shortformserver.aws.application.AmazonS3Uploader;
 import numble.team4.shortformserver.aws.dto.S3UploadDto;
+import numble.team4.shortformserver.common.dto.CommonResponse;
+import numble.team4.shortformserver.common.dto.PageInfo;
 import numble.team4.shortformserver.follow.domain.FollowRepository;
+import numble.team4.shortformserver.member.member.application.dto.MemberInfoResponse;
+import numble.team4.shortformserver.member.member.application.dto.MemberInfoResponseForAdmin;
 import numble.team4.shortformserver.member.member.domain.Member;
 import numble.team4.shortformserver.member.member.domain.MemberRepository;
 import numble.team4.shortformserver.member.member.exception.NotExistMemberException;
+import numble.team4.shortformserver.member.member.ui.dto.AllMemberInfoRequest;
 import numble.team4.shortformserver.member.member.ui.dto.MemberEmailRequest;
-import numble.team4.shortformserver.member.member.ui.dto.MemberInfoResponse;
 import numble.team4.shortformserver.member.member.ui.dto.MemberNameUpdateRequest;
 import numble.team4.shortformserver.video.domain.VideoRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
+import static numble.team4.shortformserver.member.member.ui.MemberResponseMessage.GET_MEMBER_INFO;
 
 @Service
 @Transactional(readOnly = true)
@@ -60,5 +69,17 @@ public class MemberService {
         memberRepository.save(member);
     }
 
+    public CommonResponse<List<MemberInfoResponseForAdmin>> getAllMemberInfo(AllMemberInfoRequest request, Pageable pageable) {
+        Page<MemberInfoResponseForAdmin> members = memberRepository.findAllMembersByKeyword(request.getKeyword(), pageable)
+                .map(MemberInfoResponseForAdmin::from);
+        return CommonResponse.of(members.getContent(), PageInfo.from(members), GET_MEMBER_INFO.getMessage());
+    }
+
+    @Transactional
+    public void deleteMemberById(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(NotExistMemberException::new);
+        memberRepository.delete(member);
+    }
 }
 

--- a/src/main/java/numble/team4/shortformserver/member/member/application/dto/MemberInfoResponse.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/application/dto/MemberInfoResponse.java
@@ -1,4 +1,4 @@
-package numble.team4.shortformserver.member.member.ui.dto;
+package numble.team4.shortformserver.member.member.application.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/numble/team4/shortformserver/member/member/application/dto/MemberInfoResponseForAdmin.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/application/dto/MemberInfoResponseForAdmin.java
@@ -19,6 +19,8 @@ public class MemberInfoResponseForAdmin {
     private String name;
     private Role role;
     private OauthProvider provider;
+    private LocalDateTime createAt;
+    private LocalDateTime modifiedAt;
     private LocalDateTime lastLoginDate;
     private String profileImageUrl;
     private boolean emailVerified;
@@ -31,6 +33,8 @@ public class MemberInfoResponseForAdmin {
                 member.getName(),
                 member.getRole(),
                 member.getProvider(),
+                member.getCreateAt(),
+                member.getModifiedAt(),
                 member.getLastLoginDate(),
                 member.getProfileImageUrl(),
                 member.isEmailVerified()

--- a/src/main/java/numble/team4/shortformserver/member/member/application/dto/MemberInfoResponseForAdmin.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/application/dto/MemberInfoResponseForAdmin.java
@@ -1,0 +1,39 @@
+package numble.team4.shortformserver.member.member.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import numble.team4.shortformserver.member.auth.domain.OauthProvider;
+import numble.team4.shortformserver.member.member.domain.Member;
+import numble.team4.shortformserver.member.member.domain.Role;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class MemberInfoResponseForAdmin {
+    private Long id;
+    private Long userId;
+    private String email;
+    private String name;
+    private Role role;
+    private OauthProvider provider;
+    private LocalDateTime lastLoginDate;
+    private String profileImageUrl;
+    private boolean emailVerified;
+
+    public static MemberInfoResponseForAdmin from(Member member) {
+        return new MemberInfoResponseForAdmin(
+                member.getId(),
+                member.getUserId(),
+                member.getEmail(),
+                member.getName(),
+                member.getRole(),
+                member.getProvider(),
+                member.getLastLoginDate(),
+                member.getProfileImageUrl(),
+                member.isEmailVerified()
+        );
+    }
+}

--- a/src/main/java/numble/team4/shortformserver/member/member/domain/MemberRepository.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/domain/MemberRepository.java
@@ -1,11 +1,12 @@
 package numble.team4.shortformserver.member.member.domain;
 
 import numble.team4.shortformserver.member.auth.domain.OauthProvider;
+import numble.team4.shortformserver.member.member.infrastructure.MemberCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByUserIdAndProvider(Long userId, OauthProvider provider);
     boolean existsById(Long id);

--- a/src/main/java/numble/team4/shortformserver/member/member/infrastructure/MemberCustomRepository.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/infrastructure/MemberCustomRepository.java
@@ -1,0 +1,9 @@
+package numble.team4.shortformserver.member.member.infrastructure;
+
+import numble.team4.shortformserver.member.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MemberCustomRepository {
+    Page<Member> findAllMembersByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/numble/team4/shortformserver/member/member/infrastructure/MemberCustomRepositoryImpl.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/infrastructure/MemberCustomRepositoryImpl.java
@@ -1,0 +1,40 @@
+package numble.team4.shortformserver.member.member.infrastructure;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import numble.team4.shortformserver.member.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+import static numble.team4.shortformserver.member.member.domain.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberCustomRepositoryImpl implements MemberCustomRepository {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public Page<Member> findAllMembersByKeyword(String keyword, Pageable pageable) {
+        List<Member> members = factory.selectFrom(member)
+                .where(checkContainsKeyword(keyword))
+                .orderBy(member.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        return PageableExecutionUtils.getPage(members, pageable, members::size);
+    }
+
+    BooleanExpression checkContainsKeyword(String keyword) {
+        if (Objects.isNull(keyword)) {
+            return Expressions.asBoolean(true).isTrue();
+        }
+        return member.email.contains(keyword).or(member.name.contains(keyword));
+    }
+}

--- a/src/main/java/numble/team4/shortformserver/member/member/ui/MemberController.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/ui/MemberController.java
@@ -4,14 +4,14 @@ import lombok.RequiredArgsConstructor;
 import numble.team4.shortformserver.common.dto.CommonResponse;
 import numble.team4.shortformserver.member.auth.util.LoginUser;
 import numble.team4.shortformserver.member.member.application.MailService;
+import numble.team4.shortformserver.member.member.application.dto.MemberInfoResponse;
 import numble.team4.shortformserver.member.member.application.MemberService;
+import numble.team4.shortformserver.member.member.application.dto.MemberInfoResponseForAdmin;
 import numble.team4.shortformserver.member.member.domain.Member;
-import numble.team4.shortformserver.member.member.ui.dto.EmailAuthResponse;
-import numble.team4.shortformserver.member.member.ui.dto.MemberEmailRequest;
-import numble.team4.shortformserver.member.member.ui.dto.MemberInfoResponse;
-import numble.team4.shortformserver.member.member.ui.dto.MemberNameUpdateRequest;
+import numble.team4.shortformserver.member.member.ui.dto.*;
 import numble.team4.shortformserver.video.application.VideoService;
 import numble.team4.shortformserver.video.dto.VideoListResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,6 +28,17 @@ public class MemberController {
     private final MemberService memberService;
     private final VideoService videoService;
     private final MailService mailService;
+
+    @GetMapping
+    public CommonResponse<List<MemberInfoResponseForAdmin>> findAllMember(AllMemberInfoRequest request, Pageable pageable) {
+        return memberService.getAllMemberInfo(request, pageable);
+    }
+
+    @DeleteMapping("/{memberId}")
+    public CommonResponse<Void> deleteMemberById(@PathVariable Long memberId) {
+        memberService.deleteMemberById(memberId);
+        return CommonResponse.from(DELETE_MEMBER_INFO.getMessage());
+    }
 
     @GetMapping("/{memberId}")
     public CommonResponse<MemberInfoResponse> findMemberInfo(@PathVariable Long memberId) {
@@ -50,19 +61,19 @@ public class MemberController {
     }
 
     @PutMapping("/image")
-    public CommonResponse updateProfileImage(@LoginUser Member member, MultipartFile file) {
+    public CommonResponse<Void> updateProfileImage(@LoginUser Member member, MultipartFile file) {
         memberService.saveProfileImage(member, file);
         return CommonResponse.from(SAVE_PROFILE_IMAGE.getMessage());
     }
 
     @PutMapping("/name")
-    public CommonResponse updateUserName(@LoginUser Member member, @RequestBody @Valid MemberNameUpdateRequest request) {
+    public CommonResponse<Void> updateUserName(@LoginUser Member member, @RequestBody @Valid MemberNameUpdateRequest request) {
         memberService.updateUserName(member, request);
         return CommonResponse.from(UPDATE_USER_NAME.getMessage());
     }
 
     @PostMapping("/email")
-    public CommonResponse saveEmail(@LoginUser Member member, @RequestBody @Valid MemberEmailRequest request) {
+    public CommonResponse<Void> saveEmail(@LoginUser Member member, @RequestBody @Valid MemberEmailRequest request) {
         memberService.updateUserEmail(member, request);
         return CommonResponse.from(SAVE_MEMBER_EMAIL.getMessage());
     }
@@ -72,5 +83,4 @@ public class MemberController {
         EmailAuthResponse response = mailService.sendAuthMail(request);
         return CommonResponse.of(response, GET_MAIL_AUTH_NUMBER.getMessage());
     }
-
 }

--- a/src/main/java/numble/team4/shortformserver/member/member/ui/MemberResponseMessage.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/ui/MemberResponseMessage.java
@@ -11,6 +11,7 @@ public enum MemberResponseMessage {
     GET_ALL_LIKE_VIDEOS_OF_MEMBER("회원이 좋아요를 누른 영상 목록 조회 성공"),
     GET_MEMBER_INFO("회원 정보 조회 성공"),
     SAVE_PROFILE_IMAGE("회원 프로필 이미지 저장 성공"),
+    DELETE_MEMBER_INFO("회원 정보 삭제 성공"),
     UPDATE_USER_NAME("사용자 닉네임 수정 성공"),
     GET_MAIL_AUTH_NUMBER("이메일 확인을 위한 인증 번호 발급 성공"),
     SAVE_MEMBER_EMAIL("사용자 이메일 등록 성공");

--- a/src/main/java/numble/team4/shortformserver/member/member/ui/dto/AllMemberInfoRequest.java
+++ b/src/main/java/numble/team4/shortformserver/member/member/ui/dto/AllMemberInfoRequest.java
@@ -1,0 +1,11 @@
+package numble.team4.shortformserver.member.member.ui.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AllMemberInfoRequest {
+
+    private String keyword;
+}

--- a/src/test/java/numble/team4/shortformserver/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/numble/team4/shortformserver/member/integration/MemberIntegrationTest.java
@@ -3,14 +3,18 @@ package numble.team4.shortformserver.member.integration;
 import numble.team4.shortformserver.aws.application.AmazonS3Uploader;
 import numble.team4.shortformserver.likevideo.domain.LikeVideo;
 import numble.team4.shortformserver.likevideo.domain.LikeVideoRepository;
+import numble.team4.shortformserver.member.member.application.dto.MemberInfoResponseForAdmin;
 import numble.team4.shortformserver.member.member.domain.Member;
 import numble.team4.shortformserver.member.member.domain.MemberRepository;
 import numble.team4.shortformserver.member.member.domain.Role;
+import numble.team4.shortformserver.member.member.exception.NotExistMemberException;
 import numble.team4.shortformserver.member.member.ui.MemberController;
+import numble.team4.shortformserver.member.member.ui.dto.AllMemberInfoRequest;
 import numble.team4.shortformserver.member.member.ui.dto.MemberEmailRequest;
-import numble.team4.shortformserver.member.member.ui.dto.MemberInfoResponse;
+import numble.team4.shortformserver.member.member.application.dto.MemberInfoResponse;
 import numble.team4.shortformserver.member.member.ui.dto.MemberNameUpdateRequest;
 import numble.team4.shortformserver.testCommon.BaseIntegrationTest;
+//import numble.team4.shortformserver.testCommon.mockUser.WithMockAdmin;
 import numble.team4.shortformserver.video.domain.Video;
 import numble.team4.shortformserver.video.domain.VideoRepository;
 import numble.team4.shortformserver.video.dto.VideoListResponse;
@@ -20,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.mock.web.MockMultipartFile;
 
 import javax.persistence.EntityManager;
@@ -28,7 +33,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static numble.team4.shortformserver.member.auth.domain.OauthProvider.KAKAO;
+import static numble.team4.shortformserver.member.member.domain.Role.MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @BaseIntegrationTest
@@ -60,7 +68,22 @@ public class MemberIntegrationTest {
                 .name("user2").role(Role.MEMBER).emailVerified(true)
                 .build();
         memberRepository.save(member);
+        createMember();
         createVideo();
+    }
+
+    void createMember() {
+        for (int i = 0; i < 20; i++) {
+            Member member = new Member(
+                    Integer.toUnsignedLong(i),
+                    "numble" + i + "@numble.com",
+                    "numble" + i,
+                    MEMBER,
+                    KAKAO,
+                    true
+            );
+            memberRepository.save(member);
+        }
     }
 
     void createVideo() {
@@ -77,6 +100,7 @@ public class MemberIntegrationTest {
             videoRepository.save(video);
         }
     }
+
     void createLikeVideo() {
         List<Video> all = videoRepository.findAll();
         for (int i = 0; i < all.size(); i++) {
@@ -88,8 +112,6 @@ public class MemberIntegrationTest {
     static Stream<Long> valueSources() {
         return Stream.of(null, 3L, 8L, 30L);
     }
-
-
 
     @ParameterizedTest
     @DisplayName("[성공] 마이비디오 목록 조회 (videoId가 null일 때)")
@@ -207,5 +229,43 @@ public class MemberIntegrationTest {
         assertThat(memberRepository.getById(member.getId()).getEmail()).isEqualTo(testEmail);
     }
 
+    @Test
+    @DisplayName("[성공] 어드민 페이지에서 키워드를 포함하는 모든 사용자 정보 조회")
+    void getAllMemberInfo_notException_success() {
+        //when
+        List<MemberInfoResponseForAdmin> res = memberController.findAllMember(
+                new AllMemberInfoRequest("numble"),
+                PageRequest.of(0, 30)).getData();
 
+        //then
+        assertThat(res).hasSize(20);
+    }
+
+    @Test
+    @DisplayName("[성공] 어드민 페이지에서 키워드를 포함하는 모든 사용자 정보 조회 - 키워드가 없는 경우")
+    void getAllMemberInfo_notException_success_notKeyword() {
+        //given
+        entityManager.flush();
+        entityManager.clear();
+
+        //when
+        List<MemberInfoResponseForAdmin> res = memberController.findAllMember(
+                new AllMemberInfoRequest(null),
+                PageRequest.of(0, 30)).getData();
+
+        //then
+        assertThat(res).hasSize(21);
+    }
+
+    @Test
+    @DisplayName("[실패] 어드민 페이지에서 사용자 정보 삭제")
+    void delteMemberInfo_notException_fail() {
+        //given
+        entityManager.flush();
+        entityManager.clear();
+
+        //when, then
+        assertThatThrownBy(() -> memberController.deleteMemberById(2000L))
+                .isInstanceOf(NotExistMemberException.class);
+    }
 }

--- a/src/test/java/numble/team4/shortformserver/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/numble/team4/shortformserver/member/integration/MemberIntegrationTest.java
@@ -14,7 +14,6 @@ import numble.team4.shortformserver.member.member.ui.dto.MemberEmailRequest;
 import numble.team4.shortformserver.member.member.application.dto.MemberInfoResponse;
 import numble.team4.shortformserver.member.member.ui.dto.MemberNameUpdateRequest;
 import numble.team4.shortformserver.testCommon.BaseIntegrationTest;
-//import numble.team4.shortformserver.testCommon.mockUser.WithMockAdmin;
 import numble.team4.shortformserver.video.domain.Video;
 import numble.team4.shortformserver.video.domain.VideoRepository;
 import numble.team4.shortformserver.video.dto.VideoListResponse;

--- a/src/test/java/numble/team4/shortformserver/testCommon/mockUser/WithMockAdmin.java
+++ b/src/test/java/numble/team4/shortformserver/testCommon/mockUser/WithMockAdmin.java
@@ -1,0 +1,20 @@
+package numble.team4.shortformserver.testCommon.mockUser;
+
+import numble.team4.shortformserver.member.member.domain.Role;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomAdminSecurityContextFactory.class)
+public @interface WithMockAdmin {
+
+    Role role() default Role.ADMIN;
+
+    String name() default "테스트관리자";
+
+    String email() default "admin@numble.com";
+
+    boolean emailVerified() default true;
+}

--- a/src/test/java/numble/team4/shortformserver/testCommon/mockUser/WithMockCustomAdminSecurityContextFactory.java
+++ b/src/test/java/numble/team4/shortformserver/testCommon/mockUser/WithMockCustomAdminSecurityContextFactory.java
@@ -1,0 +1,42 @@
+package numble.team4.shortformserver.testCommon.mockUser;
+
+import numble.team4.shortformserver.member.auth.domain.MemberAdapter;
+import numble.team4.shortformserver.member.member.domain.Member;
+import numble.team4.shortformserver.member.member.domain.MemberRepository;
+import numble.team4.shortformserver.testCommon.BaseDataJpaTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+@BaseDataJpaTest
+public class WithMockCustomAdminSecurityContextFactory implements WithSecurityContextFactory<WithMockAdmin> {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockAdmin withMockAdmin) {
+
+        Member member = Member.builder()
+                .email(withMockAdmin.email())
+                .name(withMockAdmin.name())
+                .role(withMockAdmin.role())
+                .emailVerified(withMockAdmin.emailVerified())
+                .build();
+
+        memberRepository.save(member);
+
+        UserDetails userDetails = new MemberAdapter(member);
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+
+        return context;
+    }
+}

--- a/src/test/java/numble/team4/shortformserver/video/integration/VideoIntegrationTest.java
+++ b/src/test/java/numble/team4/shortformserver/video/integration/VideoIntegrationTest.java
@@ -227,7 +227,7 @@ public class VideoIntegrationTest {
         @Test
         @DisplayName("특정 영상 조회 실패, 존재하지 않는 영상은 조회할 수 없다.")
         void findById_notExistVideo() throws Exception {
-            assertThrows(NotExistVideoException.class, () -> videoController.findById(100L));
+            assertThrows(NotExistVideoException.class, () -> videoController.findById(3000L));
         }
     }
 

--- a/src/test/java/numble/team4/shortformserver/video/integration/VideoIntegrationTest.java
+++ b/src/test/java/numble/team4/shortformserver/video/integration/VideoIntegrationTest.java
@@ -204,7 +204,6 @@ public class VideoIntegrationTest {
     @Nested
     @DisplayName("영상 조회 테스트")
     class GetVideoTest {
-
         @Test
         @DisplayName("특정 영상 조회 실패, 존재하지 않는 영상은 조회할 수 없다.")
         void findById_notExistVideo()  {
@@ -221,14 +220,7 @@ public class VideoIntegrationTest {
             List<VideoListResponse> all = videoController.getAllVideos().getData();
 
             // then
-            assertThat(response.getMessage()).isEqualTo(GET_VIDEO_BY_ID.getMessage());
-            assertThat(viewCount + 1).isEqualTo(data.getViewCount());
-        }
-
-        @Test
-        @DisplayName("특정 영상 조회 실패, 존재하지 않는 영상은 조회할 수 없다.")
-        void findById_notExistVideo() throws Exception {
-            assertThrows(NotExistVideoException.class, () -> videoController.findById(3000L));
+            assertThat(all).hasSize(size);
         }
     }
 


### PR DESCRIPTION
###  :speech_balloon: Motivation
* 관리자 페이지에서 회원 목록 조회 및 삭제

### :exclamation: Key changes
* 키워드를 기반으로 회원 목록 조회 - 키워드가 이메일 또는 이름에 포함되면 검색됨
* 회원 ID로 삭제
* 관리자만 요청 가능하도록 Security 설정

###  :pencil2: To Reviewers

